### PR TITLE
Fixed spelling for SEND_FAILURE status

### DIFF
--- a/api/src/main/java/jakarta/security/auth/message/AuthStatus.java
+++ b/api/src/main/java/jakarta/security/auth/message/AuthStatus.java
@@ -70,7 +70,7 @@ public class AuthStatus {
 		case 3:
 			return "AuthStatus.SEND_SUCCESS";
 		case 4:
-			return "AuthStatus.SEND_FAILUR";
+			return "AuthStatus.SEND_FAILURE";
 		case 5:
 			return "AuthStatus.SEND_CONTINUE";
 		default:


### PR DESCRIPTION
Hi,

not sure if this is indeed a spelling error, but after a quick search, there's no other usage of the constant `SEND_FAILUR`

 ![Screenshot 2020-02-16 at 00 54 59](https://user-images.githubusercontent.com/5684688/74597431-bc54a300-505f-11ea-8fe4-0b4415e49fbf.png)
