### PR TITLE
Fixed spelling for SEND_FAILURE status

### DIFF
--- a/api/src/main/java/jakarta/security/auth/message/AuthStatus.java
+++ b/api/src/main/java/jakarta/security/auth/message/AuthStatus.java
@@ -70,7 +70,7 @@ public class AuthStatus {
 		case 3:
 			return "AuthStatus.SEND_SUCCESS";
 		case 4:
-			return "AuthStatus.SEND_FAILUR";
+			return "AuthStatus.SEND_FAILURE";
 		case 5:
 			return "AuthStatus.SEND_CONTINUE";
 		default:


### PR DESCRIPTION
Hi, not sure if this is indeed a spelling issue, but after a quick search, it seems that there are no other usages of the constant `SEND_FAILUR` in the api itself, but the declaration of the constant itself:

![Screenshot 2020-02-16 at 00 54 59](https://user-images.githubusercontent.com/5684688/74597613-9ed50880-5062-11ea-80bb-8329455baded.png)


Signed-off-by: Thodoris Bais <thodoris.bais@gmail.com>