### PR TITLE
Apply updates to CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -31,11 +31,10 @@ electronically sign the Eclipse Contributor Agreement (ECA).
 
 * http://www.eclipse.org/legal/ECA.php
 
-Commits that are provided by non-committers must have a Signed-off-by field in
-the footer indicating that the author is aware of the terms by which the
-contribution has been provided to the project. The non-committer must
-additionally have an Eclipse Foundation account and must have a signed Eclipse
-Contributor Agreement (ECA) on file.
+The credentials of the actual author must be used to populate the Author field.
+The author credentials must specify the author’s actual (legal) name and email
+address. The email address used must match the email address that the Eclipse
+Foundation has on file for the author (case-sensitive).
 
 For more information, please see the Eclipse Committer Handbook:
 https://www.eclipse.org/projects/handbook/#resources-commit

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,18 +11,18 @@ and pass an authenticated identity (such as name and groups) to the container.
 Jakarta Authentication consists of several profiles, with each profile telling how a specific container
 (such as Jakarta Servlet) can integrate with- and adapt to this SPI.
 
-* https://projects.eclipse.org/projects/ee4j.jaspic
+* https://projects.eclipse.org/projects/ee4j.authentication
 
 ## Developer resources
 
 Information regarding source code management, builds, coding standards, and
 more.
 
-* https://projects.eclipse.org/projects/ee4j.jaspic/developer
+* https://projects.eclipse.org/projects/ee4j.authentication/developer
 
 The project maintains the following source code repositories
 
-* https://github.com/eclipse-ee4j/jaspic
+* https://github.com/eclipse-ee4j/authentication
 
 ## Eclipse Contributor Agreement
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -56,6 +56,10 @@ Jakarta EE specification projects.
 
 ## Contact
 
-Contact the project developers via the project's "dev" list.
+The project developers can be contacted via the jaspic-dev@eclipse.org mailing
+list.
 
-*
+Before emailing the list you must subscribe at:
+
+* https://accounts.eclipse.org/mailing-list/jaspic-dev
+


### PR DESCRIPTION
1. Reflect latest ECA requirements to use "Author" instead of "Signed-Off".
2. Adjust links to use "authentication" instead of "jaspic".
3. Add mailing list information.
